### PR TITLE
Reuse sound threads and lines

### DIFF
--- a/src/gods/game/GodsGame.java
+++ b/src/gods/game/GodsGame.java
@@ -20,6 +20,7 @@ import gods.screens.GodsMainMenuScreen;
 import gods.screens.JotdScreen;
 import gods.sys.GameEngine;
 import gods.sys.Localizer;
+import gods.sys.SoundService;
 import micromod.MicromodPlayer;
 
 
@@ -92,7 +93,7 @@ public class GodsGame extends GameEngine
 			  m_player = new MicromodPlayer(new File(path).toURI().toURL());
 			  m_player.setloop(loop);
 			  m_player.set_start_offset(initial_position);
-			  new Thread(m_player).start();
+			  SoundService.execute(m_player);
 		  }
 		  catch (Exception e)
 		  {

--- a/src/gods/sys/GameEngine.java
+++ b/src/gods/sys/GameEngine.java
@@ -26,9 +26,11 @@ import javax.swing.JFrame;
 
 public abstract class GameEngine 
 {
-	private static final int WAIT_MILLIS = 20;
-	private static final int MIN_FPS = 25;
-	private static final int MAX_FPS = 50;
+	private static final int CPUS = Runtime.getRuntime().availableProcessors();
+	private static final int WAIT_MILLIS = 10;
+	private static final int MAX_ELAPSED = WAIT_MILLIS * 16;
+	private static final int MAX_FPS = 50 + (CPUS * 2);
+	private static final int MIN_FPS = MAX_FPS / 2;
 	
 	private int m_max_fps = MAX_FPS;
 	private JFrame m_window;
@@ -173,6 +175,9 @@ public abstract class GameEngine
 		
 		m_window.addComponentListener(new GameWindowListener());
 		m_canvas.requestFocus();
+		
+		System.out.println("Game size: " + m_canvas.getWidth() + "x" + m_canvas.getHeight() + " - Scaling factor: " + m_scale_factor 
+				+ " - CPUs: " + CPUS + " - Max FPS: " + m_max_fps);
 	}
 
     public void start()
@@ -251,9 +256,9 @@ public abstract class GameEngine
        		
        		// safety to avoid too much delay between 2 updates
        		
-       		if (elapsed_time > WAIT_MILLIS * 20)
+       		if (elapsed_time > MAX_ELAPSED)
        		{
-       			elapsed_time = WAIT_MILLIS * 20;
+       			elapsed_time = MAX_ELAPSED;
        			accumulated = 0;
        		}
 
@@ -314,7 +319,7 @@ public abstract class GameEngine
 				actualWidth = (int)(m_useful_bounds.width * actualScale);
 				actualHeight = (int)(m_useful_bounds.height * actualScale);
 				scaleTransform = AffineTransform.getScaleInstance(actualScale, actualScale);
-				m_max_fps = Math.max(MIN_FPS, MAX_FPS - (int)(5 * actualScale));
+				m_max_fps = Math.max(MIN_FPS, MAX_FPS - (int)((CPUS/2) * actualScale));
 			} else {
 				// Minimum size allowed
 				actualScale = 1.0;
@@ -354,7 +359,6 @@ public abstract class GameEngine
 				super.processKeyEvent(evt);
 				return;
 			}
-			evt.consume();
 			double delta = 0.0;
 			if (evt.getKeyCode() == KeyEvent.VK_PLUS || evt.getKeyCode() == KeyEvent.VK_ADD) {
 				// Zoom in
@@ -367,16 +371,12 @@ public abstract class GameEngine
 				delta = 1.0 - m_scale_factor;
 			}
 			m_canvas.zoom(delta);
+			super.processKeyEvent(evt);
 		}
 		
 		@Override
 		public boolean isOptimizedDrawingEnabled() {
 			return true;
-		}
-		
-		@Override
-		public boolean isDoubleBuffered() {
-			return false;
 		}
 		
 		@Override

--- a/src/gods/sys/Mp3Play.java
+++ b/src/gods/sys/Mp3Play.java
@@ -1,9 +1,8 @@
 package gods.sys;
 
-import javazoom.jl.player.Player;
-
-import java.io.BufferedInputStream;
 import java.io.FileInputStream;
+
+import javazoom.jl.player.Player;
 
 public class Mp3Play implements Runnable
 {
@@ -11,12 +10,12 @@ public class Mp3Play implements Runnable
 	
 	private String m_mp3_name;
 	private Player m_player;
-	private Thread m_play_thread;
+	private boolean m_playing;
 	private boolean m_repeat;
 	
 	public static boolean is_playing()
 	{
-		return m_instance.is_music_playing();
+		return m_instance.m_playing;
 	}
 
 	public static void play(String mp3_name, boolean repeat)
@@ -48,13 +47,7 @@ public class Mp3Play implements Runnable
 	private void play_music(boolean repeat)
 	{
 		m_repeat = repeat;
-		m_play_thread = new Thread(this);
-		m_play_thread.start();
-	}
-
-	private boolean is_music_playing()
-	{
-		return m_play_thread != null && m_play_thread.isAlive();
+		SoundService.execute(this);
 	}
 
 	private synchronized void stop_music()
@@ -64,7 +57,7 @@ public class Mp3Play implements Runnable
 			System.out.println("Stop playing " + m_mp3_name);
 			m_player.close();
 			m_player = null;
-			m_play_thread = null;
+			m_playing = false;
 		}
 	}
 
@@ -73,12 +66,17 @@ public class Mp3Play implements Runnable
 		try (FileInputStream fileStream = new FileInputStream(m_mp3_name))
 		{
 			System.out.println("Start playing " + m_mp3_name);
+			m_playing = true;
 			m_player = new Player(fileStream);
 			m_player.play();
 		}
 		catch (Exception e)
 		{
 			e.printStackTrace();
+		}
+		finally
+		{
+			m_playing = false;
 		}
 	}
 }

--- a/src/gods/sys/Mp3Play.java
+++ b/src/gods/sys/Mp3Play.java
@@ -70,11 +70,10 @@ public class Mp3Play implements Runnable
 
 	public void run()
 	{
-		try (FileInputStream fileStream = new FileInputStream(m_mp3_name);
-				BufferedInputStream bufferedStream = new BufferedInputStream(fileStream))
+		try (FileInputStream fileStream = new FileInputStream(m_mp3_name))
 		{
 			System.out.println("Start playing " + m_mp3_name);
-			m_player = new Player(bufferedStream);
+			m_player = new Player(fileStream);
 			m_player.play();
 		}
 		catch (Exception e)

--- a/src/gods/sys/SoundService.java
+++ b/src/gods/sys/SoundService.java
@@ -1,0 +1,23 @@
+package gods.sys;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Executes sound tasks using a limited thread pool to avoid excessive spawn.
+ */
+public class SoundService
+{
+	static final int MAX_LINES = 8;
+	static final ExecutorService executor = Executors.newFixedThreadPool(MAX_LINES);
+	
+	public static void execute(Runnable task)
+	{
+		executor.execute(task);
+	}
+	
+	static void shutdown()
+	{
+		executor.shutdown();
+	}
+}

--- a/src/gods/sys/WavDataPlayer.java
+++ b/src/gods/sys/WavDataPlayer.java
@@ -1,0 +1,205 @@
+package gods.sys;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
+
+class WavDataPlayer implements Runnable
+{
+	static final int MAX_LINE = Math.max(4, Math.min(Runtime.getRuntime().availableProcessors()-1, 7));
+	static final int MAX_LINE_PER_TYPE = MAX_LINE - 2;
+	
+	static final ExecutorService soundService = Executors.newFixedThreadPool(MAX_LINE);
+	static final Map<Integer, Queue<SourceDataLine>> soundLines = new ConcurrentHashMap<>();
+	
+	byte[] data = null;
+	final AtomicInteger sample_position = new AtomicInteger(0);
+	DataLine.Info info;
+	int info_id;
+	String name;
+	int frame_size;
+	int rewind_mark;
+	final AtomicBoolean running = new AtomicBoolean(false);
+	boolean loop = false;
+	
+	WavDataPlayer(File fileIn)
+	{
+		try
+		{
+			if (!fileIn.exists()) {
+				throw new IllegalArgumentException("File does not exist: " + fileIn);
+			}
+			this.name = fileIn.getName();
+			
+			try (AudioInputStream audioStream = AudioSystem
+					.getAudioInputStream(new ByteArrayInputStream(Files.readAllBytes(fileIn.toPath())))) {
+				
+				AudioFormat audioFormat = audioStream.getFormat();
+				info = new DataLine.Info(SourceDataLine.class, audioFormat);
+				info_id = info.toString().hashCode();
+				
+				// Load clip data from input stream
+				ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			    int nRead;
+			    byte[] chunk = new byte[4096];
+			    while ((nRead = audioStream.read(chunk, 0, chunk.length)) != -1) {
+			        buffer.write(chunk, 0, nRead);
+			    }
+
+			    buffer.flush();
+			    data = buffer.toByteArray();
+			    
+				frame_size = audioFormat.getFrameSize();
+				rewind_mark = data.length / 2;
+				//System.out.println("clip "+ name + " rewind: " + rewind_mark + " total: " + data.length + " frame: " + frame_size);
+			}
+			catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		catch (Exception ex) {
+			System.err.println("error: on loading sound - " + ex);
+			data = null;
+		}	
+	}
+	
+	private SourceDataLine crateLine() {
+		try {
+			SourceDataLine line = (SourceDataLine) AudioSystem.getLine(info);
+			line.open(line.getFormat(), 4096 * line.getFormat().getFrameSize());
+			//clipLines.forEach((k,v) -> {debug("line [" + k + "][" + v.size() + "]");});
+			return line;
+		} catch (LineUnavailableException e) {
+			throw new IllegalStateException("Invalid line info " + info, e);
+		}
+	}
+	
+	private SourceDataLine acquireLine() {
+		Queue<SourceDataLine> lines = soundLines.computeIfAbsent(info_id, key -> new ConcurrentLinkedQueue<>());
+		SourceDataLine line = lines.poll();
+		if (line == null) {
+			line = crateLine();
+		}
+		return line;
+	}
+	
+	private void releaseLine(SourceDataLine line) {
+		Queue<SourceDataLine> queue = soundLines.get(info_id);
+		if (queue.size() < MAX_LINE_PER_TYPE) {
+			// Keep line in queue
+			//debug("offer");
+			queue.offer(line);
+		}
+		else {
+			// Free the line
+        	//debug("close");
+        	line.stop();
+        	line.flush();
+        	line.close();
+		};	
+	}
+	
+	@Override
+	public void run() {
+		try {
+			//debug("run");
+			
+			SourceDataLine sdl = acquireLine();
+			sdl.start();
+			
+			int buffer_size = sdl.getBufferSize();
+			int pos = seek(0);
+			
+			do {
+				forward(buffer_size);
+				sdl.write(data, pos, Math.min(data.length - pos, buffer_size));
+			} while (running.get() && (pos = sample_position.get()) < data.length);
+			
+			releaseLine(sdl);	
+		}
+		catch (Exception e) {
+			System.err.println("error: playing - " + name + " : " + e);
+		}
+		finally {
+			running.set(false);
+		}
+	}
+	
+	private int integral(int value, int slice) {
+		return (value/slice) * slice;
+	}
+	
+	private int forward(int length) {
+		int next = sample_position.get() + length;
+		if (next >= data.length && loop) {
+			return seek(0);
+		} 
+		return seek(Math.min(next, data.length));
+	}
+	
+	boolean runnable() {
+		return running.compareAndSet(false, true);
+	}
+	
+	int seek(int pos) {
+		if (pos == 0 || pos == data.length) {
+			return sample_position.updateAndGet(curr -> pos);
+		}
+		int adjust = Math.max(Math.min(pos, data.length), 0);
+		return sample_position.updateAndGet(curr -> integral(adjust, frame_size));
+	}
+	
+	void start(boolean loop) {
+		//debug("start");
+		this.loop = loop;
+		soundService.execute(this);
+	}
+	
+	void rewind() {
+		seek(0);
+	}
+	
+	void loop() {
+		loop = true;
+	}
+	
+	void pause() {
+		loop = false;
+	}
+	
+	void stop() {
+		running.set(false);
+	}
+	
+	void close() {
+		//debug("close");
+		stop();
+		data = null;
+		info = null;
+	}
+	
+	void debug(String action) {
+		System.out.println(action + " " + name + "[" + info_id + "] - pos: " + sample_position.get() +
+				" loop: " + loop + " thread: " + Thread.currentThread());
+	}
+	
+	static void shutdown() {
+		soundService.shutdown();
+	}
+}

--- a/src/gods/sys/WavLoop.java
+++ b/src/gods/sys/WavLoop.java
@@ -1,170 +1,32 @@
 package gods.sys;
 
-
 public class WavLoop extends WavSound
-{
-	private byte [] resampled = null;
-	private int buffer_length = 0;
-	
-	
-	private volatile boolean m_playing = true;
-	
-	/*private void handle_resampling()
-	{
-		if (do_resample)
-		{
-			do_resample = false;
-			// resample the data
-			
-			float us_ratio = buffer_length / (float)current.data.length;
-			
-			// undersample
-			for (int i = 0; i < current.data.length; i++)
-			{
-				int j = Math.round(i*us_ratio);
-				resampled[j] = current.data[i];
-			}
-		}
-			
-	}*/
-	
+{	
 	public WavLoop(String file_prefix)
 	{
 		super(file_prefix);
-		if (current.data != null)
-		{
-			buffer_length = current.data.length;
-
-			resampled = new byte [current.data.length * 2];
-			for (int i = 0; i < current.data.length; i++)
-			{
-				resampled[i] = current.data[i];
-			}		
-		}
 	}
-
+	
 	public void pause()
 	{
-		synchronized(this)
-		{
-			m_playing = false;
-			//notify();
-		}
+		current.pause();	
 	}
 	
-	public void end()
-	{
-		synchronized(this)
-		{
-			m_playing = false;
-			notify();
-			play_thread = null;
-		}
-	}
 	public void play()
-	{
-		synchronized(this)
-		{
-			m_playing = true;
-			notify();
-		}
-	}
-	
-	public void set_resampling_ratio(float ratio)
-	{
-		int frame_size = get_sdl().getFormat().getFrameSize();
-		int new_length = Math.round(current.data.length / (ratio * frame_size)) * frame_size;
-		if (new_length > resampled.length)
-		{
-			new_length = resampled.length;
-		}
-
-		if (buffer_length != new_length)
-		{
-			buffer_length = new_length;
-			//do_resample = true;
-		}		
-	}
-	public void run()
-	{
-		if (current.data != null)
-		{
-		Thread this_thread = Thread.currentThread();
-		int frame_size = get_sdl().getFormat().getFrameSize();
-		//float sampling_rate = get_sdl().getFormat().getSampleRate();
-		
-		float split_seconds = 0.1f;
-		long split_wait = (long)(900 * split_seconds); // 90% of the time
-		long nb_split_bytes = Math.round(current.sound_length / split_seconds);
-		
-		if (nb_split_bytes == 0)
-		{
-			nb_split_bytes = 1;
-		}
-
-		int write_block = current.data.length / (int)nb_split_bytes;		
-		
-		// must be a multiple of the frame size
-		
-		write_block = (write_block / frame_size) * frame_size;
-
-		try
-		{			
-			synchronized(this)
-			{
-				wait();
+	{	
+		final WavDataPlayer actual = current;
+		if (actual.data != null) {
+			if (actual.runnable()) {
+				// The data line is free to play
+				actual.start(true);
 			}
-
-			get_sdl().start();
-
-			if (current.data != null)
-			{
-				while (play_thread == this_thread)
-				{		
-					set_sample_position(0);
-					
-					while (get_sample_position() < current.data.length)
-					{
-						int sp = get_sample_position();
-						set_sample_position(sp + write_block);
-
-
-						if (!m_playing)
-						{
-							synchronized(this)
-							{
-								get_sdl().flush();
-								wait();
-							}
-						}
-						
-						if (play_thread != null)
-						{
-							//handle_resampling();
-
-							write(current.data,sp,Math.min(write_block,current.data.length - sp));
-
-							// wait 90% of the theorical playing time
-							// so when the loop stops there is not a lot of buffered sound
-							// to play
-
-							if (split_wait < 40)
-							{
-								Thread.sleep(split_wait);
-							}
-						}
-					}
-				}	
+			else {
+				// Reuse the running line
+				actual.loop();
 			}
-
 		}
-		catch (Exception ex)
-		{
-
-		}
-		close();
+		else {
+			System.err.println("error: no loop to play - " + actual.name);
 		}
 	}
-
-
 }

--- a/src/gods/sys/WavSample.java
+++ b/src/gods/sys/WavSample.java
@@ -37,7 +37,7 @@ public class WavSample extends WavSound
 		sound.stop();
 		System.out.println(new Date());
 		
-		WavDataPlayer.shutdown();
+		SoundService.shutdown();
 		System.out.println(new Date());
 	}		
 }

--- a/src/gods/sys/WavSample.java
+++ b/src/gods/sys/WavSample.java
@@ -1,115 +1,43 @@
 package gods.sys;
 
+import java.util.Date;
 
 public class WavSample extends WavSound
-{
-	private volatile boolean m_stop_flag = false;
-	
-	public WavSample(String file_prefix, double volume)
-	{
-		super(file_prefix,volume);
-	}
+{	
 	public WavSample(String file_prefix)
 	{
 		super(file_prefix);
 	}
-
-	public void stop()
-	{
-		m_stop_flag = true;
-	}
-	public void run()
-	{
-		if (current.data != null)
-		{
-		Thread this_thread = Thread.currentThread();
-		int frame_size = get_sdl().getFormat().getFrameSize();
-		
-		float split_seconds = 0.1f;
-		long split_wait = (long)(900 * split_seconds); // 900 = 90% of the time WTF does that mean???
-		long nb_split_bytes = Math.round(current.sound_length / split_seconds);
-		
-		if (nb_split_bytes == 0)
-		{
-			nb_split_bytes = 1;
-		}
-		
-		int write_block = current.data.length / (int)nb_split_bytes;		
-		
-		// must be a multiple of the frame size
-		
-		write_block = (write_block / frame_size) * frame_size;
-
-		
-		try
-		{			
-			get_sdl().start();
-
-			while (play_thread == this_thread)
-			{	
-				if (m_stop_flag)
-				{
-					set_sample_position(0);
-					get_sdl().flush();
-				}
-				
-				
-				synchronized(this)
-				{
-					wait();
-					if (!m_stop_flag)
-					{
-						get_sdl().flush();
-					}
-					//m_stop_flag = false;
-				}
-				if (play_thread != null)
-				{
-					while (get_sample_position() < get_max_sample_position())
-					{
-				
-						int sp = get_sample_position();
-						set_sample_position(sp + write_block);
-						
-						// other thread can call set_sample_position(0) now
-						
-						if (m_stop_flag)
-						{
-							set_sample_position(0);
-							get_sdl().flush();
-							break;
-						}
-						write(current.data,sp,Math.min(write_block,current.data.length - sp));
-
-						if ((!m_stop_flag)&& (split_wait < 20))
-						{
-							Thread.sleep(split_wait);
-						}
-					}
-					m_stop_flag = false;
-				}
-				
-			}
-		}
-		catch (Exception ex)
-		{
-
-		}
-		close();
-		}
-	}
-
-
 	
-		/**
-	 * @param args
-	 */
+	public void play_offset(int index)
+	{	
+		set_sample_position(index);
+	}
+	
 	public static void main(String[] args) throws Exception
 	{
-		WavSound sp = new WavSample("mine");
-		sp.play();
+		int avpro = Runtime.getRuntime().availableProcessors();
+		System.out.println("Available Processors : " + avpro);
+		System.out.println(new Date());
+		
+		WavLoop sound = new WavLoop("spike");
+		//WavSound sound = new WavSample("starburst");
+		sound.play();
+		
+		for (int i = 0; i < 100; i++) {
+			sound.pause();
+			Thread.sleep(100);
+			if (i % 33 == 0) {
+				sound.play();
+			}
+			Thread.sleep(100);
+		}
 
-		Thread.sleep(4000);
-	}	
-	
-	}
+		//Thread.sleep(3000);
+		sound.stop();
+		System.out.println(new Date());
+		
+		WavDataPlayer.shutdown();
+		System.out.println(new Date());
+	}		
+}


### PR DESCRIPTION
### The problem
Trying to run GD on my old netbook (Atom 32 bit, 1GB RAM). After few seconds the game crash with crazy CPU. After investigation: too many threads and opened data lines due sound management.

### Solution stragegy
- Limited threads (using `Executors.newFixedThreadPool`)
- Limited `SourceDataLine` by reusing them with a FIFO queue

### Result
Now my old netbook is happy. The game doesn't play perfectly (still a bit slow and some clicks during audio play), but it plays. Modern PCs play it smoothly using less resources.